### PR TITLE
module.vim: fix a forgotten b:undo_ftplugin

### DIFF
--- a/ftdetect/module.vim
+++ b/ftdetect/module.vim
@@ -9,3 +9,5 @@ endif
 let b:did_ftplugin = 1
 
 autocmd BufNewFile,BufRead *.module.css,*.mod.css set filetype=css.module
+
+let b:undo_ftplugin = ""


### PR DESCRIPTION
If you set b:did_ftplugin, you should also set b:undo_ftplugin, otherwise strange things happen.

https://stackoverflow.com/questions/11425906/should-every-ftplugin-name-vim-need-to-define-bundo-ftplugin